### PR TITLE
#4 and #11 done

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ Extension attributes are listed below in support matrix:
 | `child_page` | Page inside | + | - | + |  |
 | `child_database` | Database inside | + | - | + |  |
 | `embed` | Embed online content | + | - | - | `caption: RichTextArray` |
-| `image` |  | - | - | - |  |
-| `video` |  | - | - | - |  |
-| `file` |  | - | - | - |  |
-| `pdf` |  | - | - | - |  |
+| `image` | Embed image content | + | - | - | `caption: RichTextArray`, `expiry_time: datetime` |
+| `video` | Embed video content | + | - | - | `caption: RichTextArray`, `expiry_time: datetime` |
+| `file` | Embed file content | + | - | - | `caption: RichTextArray`, `expiry_time: datetime` |
+| `pdf` | Embed pdf content | + | - | - | `caption: RichTextArray`, `expiry_time: datetime` |
 | `bookmark` | Block for URL Link | + | - | - | `caption: RichTextArray` |
 | `callout` | Highlighted footnote text Block | + | - | + | `icon: dict` |
 | `quote` | Text Block with quote style | + | - | + |  |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Extension attributes are listed below in support matrix:
 | `code` | Text Block with code style | + | + | + | `language: str`, `caption: RichTextArray` |
 | `child_page` | Page inside | + | - | + |  |
 | `child_database` | Database inside | + | - | + |  |
-| `embed` | Embed online content | + | - | - |  |
+| `embed` | Embed online content | + | - | - | `caption: RichTextArray` |
 | `image` |  | - | - | - |  |
 | `video` |  | - | - | - |  |
 | `file` |  | - | - | - |  |

--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ Extension attributes are listed below in support matrix:
 | `quote` | Text Block with quote style | + | - | + |  |
 | `equation` | KaTeX compatible text Block | + | - | - |  |
 | `divider` | Simple line to divide the page | + | - | - |  |
-| `table_of_contents` | Block with content structure in the page | - | - | - |  |
+| `table_of_contents` | Block with content structure in the page | + | - | - |  |
 | `column` |  | - | - | + |  |
 | `column_list` |  | - | - | - |  |
-| `link_preview` |  Same as `bookmark` | - | - | - |  |
-| `synced_block` | Block for synced content aka parent | - | - | + |  |
-| `template` | Template Block title | - | - | + |  |
-| `link_to_page` | Block with link to particular page `@...` | - | - | - |  |
+| `link_preview` |  Same as `bookmark` | + | - | - |  |
+| `synced_block` | Block for synced content aka parent | + | - | + | `synced_from: LinkTo` |
+| `template` | Template Block title | + | - | + |  |
+| `link_to_page` | Block with link to particular page `@...` | + | - | - | `link: LinkTo` |
 | `table` | Table Block with some attrs | - | - | + |  |
 | `table_row` | Children Blocks with table row content | - | - | - |  |
 | `breadcrumb` | Empty Block actually | + | - | - |  |

--- a/README.md
+++ b/README.md
@@ -137,12 +137,48 @@ Extension attributes are listed below in support matrix:
 | `synced_block` | Block for synced content aka parent | + | - | + | `synced_from: LinkTo` |
 | `template` | Template Block title | + | - | + |  |
 | `link_to_page` | Block with link to particular page `@...` | + | - | - | `link: LinkTo` |
-| `table` | Table Block with some attrs | - | - | + |  |
-| `table_row` | Children Blocks with table row content | - | - | - |  |
+| `table` | Table Block with some attrs | + | - | + | `table_width: int` |
+| `table_row` | Children Blocks with table row content | + | - | - |  |
 | `breadcrumb` | Empty Block actually | + | - | - |  |
 | `unsupported` | Blocks unsupported by API | + | - | - |  |
 
 API converts **toggle heading** Block to simple heading Block.
+
+### Block creating examples
+
+Create `paragraph` block object and add it to Notion:
+
+```
+from pytion.models import Block
+my_text_block = Block.create("Hello World!")
+my_text_block = Block.create(text="Hello World!", type_="paragraph")  # the same
+
+# indented append my block to other known block:
+no.blocks.block_append("5f60073a9dda4a9c93a212a74a107359", block=my_text_block)
+
+# append my block to a known page (in the end)
+no.blocks.block_append("9796f2525016128d9af4bf12b236b555", block=my_text_block)  # the same operation actually
+
+# another way to append:
+my_page = no.pages.get("9796f2525016128d9af4bf12b236b555")
+my_page.block_append(block=my_text_block)
+```
+
+Create `to_do` block object:
+
+```
+from pytion.models import Block
+my_todo_block = Block.create("create readme documentation", type_="to_do")
+my_todo_block2 = Block.create("add 'create' method", type_="to_do", checked=True)
+```
+
+Create `code` block object:
+
+```
+from pytion.models import Block
+my_code_block = Block.create("code example here", type_="code", language="javascript")
+my_code_block2 = Block.create("another code example", type_="code", caption="it will be plain text code block with caption")
+```
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pytion
+
 Unofficial Python client for official Notion API (for internal integrations only)
 
 Supports Notion API version = **"2022-02-22"**
@@ -6,6 +7,7 @@ Supports Notion API version = **"2022-02-22"**
 Works with **Python 3.8+**
 
 ## Quick start
+
 There is no package yet. Clone repo.
 
 Create new integration and get your Notion API Token at notion.so -> /my-integrations
@@ -15,6 +17,7 @@ Invite your new integration 'manager' to your Notion workspace or particular pag
 `from pytion import Notion; no = Notion(token=SOME_TOKEN)`
 
 Or put your token for Notion API into file `token` at script directory and use simple `no = Notion()`
+
 ```
 from pytion import Notion
 no = Notion(token=SOME_TOKEN)
@@ -22,6 +25,7 @@ page = no.pages.get("PAGE ID")
 database = no.databases.get("Database ID")
 pages = database.db_filter(property_name="Done", property_type="checkbox", value=False, descending="title")
 ```
+
 ```
 In [12]: no = Notion(token=SOME_TOKEN)
 
@@ -38,8 +42,11 @@ Paragraph
         block inside block
 some text
 ```
+
 ## Available methods
+
 ### pytion.api.Element
+
 `.get(id_)` - Get Element by ID.
 
 `.get_parent(id_)` - Get parent object of current object if possible.
@@ -69,17 +76,24 @@ some text
 `.from_linkto(linkto)` - Creates new Element object based on LinkTo information.
 
 `.from_object(model)` - Creates new Element object from Page, Block or Database object.
+
 Usable while Element object contains an Array.
 
 More details and examples of this methods you can see into func descriptions.
+
 ### pytion.models.*
+
 There are user classmethods for models:
+
 `RichTextArray.create()`, `Property.create()`, `PropertyValue.create()`, `Database.create()`, `Page.create()`, `Block.create()`, `LinkTo.create()`, `User.create()`
+
 ### Supported block types
+
 At present the API only supports the block types which are listed in the reference below. Any unsupported block types will continue to appear in the structure, but only contain a `type` set to `"unsupported"`.
 Colors are not yet supported.
 
 Every Block has mandatory attributes and extension attributes. There are mandatory:
+
 - `id: str` - UUID-64 without hyphens
 - `object: str` - always `"block"` (from API)
 - `created_time: datetime` - from API
@@ -106,7 +120,7 @@ Extension attributes are listed below in support matrix:
 | `code` | Text Block with code style | + | + | + | `language: str`, `caption: RichTextArray` |
 | `child_page` | Page inside | + | - | + |  |
 | `child_database` | Database inside | + | - | + |  |
-| `embed` |  | - | - | - |  |
+| `embed` | Embed online content | + | - | - |  |
 | `image` |  | - | - | - |  |
 | `video` |  | - | - | - |  |
 | `file` |  | - | - | - |  |
@@ -131,7 +145,9 @@ Extension attributes are listed below in support matrix:
 API converts **toggle heading** Block to simple heading Block.
 
 ## Logging
+
 Logging is muted by default. To enable to stdout and/or to file:
+
 ```
 from pytion import setup_logging
 

--- a/pytion/models.py
+++ b/pytion/models.py
@@ -609,9 +609,9 @@ class Block(Model):
         elif self.type == "embed":
             self.caption = RichTextArray(kwargs[self.type].get("caption"))
             if self.caption:
-                self.text: str = f'[{self.caption}]({kwargs[self.type].get("url")})'
+                self.text = f'[{self.caption}]({kwargs[self.type].get("url")})'
             else:
-                self.text: str = f'<{kwargs[self.type]["url"]}>' if kwargs[self.type].get("url") else "*Empty embed*"
+                self.text = f'<{kwargs[self.type]["url"]}>' if kwargs[self.type].get("url") else "*Empty embed*"
 
         elif self.type == "image":
             self.caption = RichTextArray(kwargs[self.type].get("caption"))
@@ -679,9 +679,16 @@ class Block(Model):
         elif self.type == "bookmark":
             self.caption = RichTextArray(kwargs[self.type].get("caption"))
             if self.caption:
-                self.text: str = f'[{self.caption}]({kwargs[self.type].get("url")})'
+                self.text = f'[{self.caption}]({kwargs[self.type].get("url")})'
             else:
-                self.text: str = f'<{kwargs[self.type]["url"]}>' if kwargs[self.type].get("url") else "*Empty bookmark*"
+                self.text = f'<{kwargs[self.type]["url"]}>' if kwargs[self.type].get("url") else "*Empty bookmark*"
+
+        elif self.type == "link_preview":
+            self.text = f'<{kwargs[self.type].get("url")}>'
+
+        elif self.type == "link_to_page":
+            self.link = LinkTo(**kwargs[self.type])
+            self.text = repr(self.link)
 
         elif self.type == "equation":
             self.text: str = kwargs[self.type].get("expression")
@@ -690,7 +697,15 @@ class Block(Model):
             self.text = "---"
 
         elif self.type == "table_of_contents":
-            self.text = self.type
+            self.text = "*Table of contents*"
+
+        elif self.type == "template":
+            self.text = RichTextArray.create("Template: ") + RichTextArray(kwargs[self.type].get("rich_text"))
+
+        elif self.type == "synced_block":
+            synced_from = kwargs[self.type].get("synced_from")
+            self.text = "*SYNCED BLOCK:*"
+            self.synced_from = LinkTo(**synced_from) if synced_from else None
 
         elif self.type == "unsupported":
             self.text = "*****"
@@ -838,6 +853,8 @@ class LinkTo(object):
             # when type is set manually
             elif self.type == "page":
                 self.uri = "pages"
+            elif self.type == "block_id":
+                self.uri = "blocks"
             else:
                 self.uri = None
 

--- a/pytion/models.py
+++ b/pytion/models.py
@@ -39,6 +39,7 @@ class RichText(object):
                     "end": Model.format_iso_time(kwargs[self.type][subtype].get("end"))
                 }
             elif subtype == "link_preview":
+                self.plain_text = f"<{self.plain_text}>"
                 self.data: Dict = kwargs[self.type]
         else:
             self.data: Dict = kwargs[self.type]
@@ -604,12 +605,23 @@ class Block(Model):
             # database with custom source had no title!
             # if child database - can we set self.parent? - well no.
 
-        elif self.type in ["embed", "image", "video", "file", "pdf", "breadcrumb"]:
+        # hello, markdown
+        elif self.type == "embed":
+            self.caption = RichTextArray(kwargs[self.type].get("caption"))
+            if self.caption:
+                self.text: str = f'[{self.caption}]({kwargs[self.type].get("url")})'
+            else:
+                self.text: str = f'<{kwargs[self.type]["url"]}>' if kwargs[self.type].get("url") else "*Empty embed*"
+
+        elif self.type in ["image", "video", "file", "pdf", "breadcrumb"]:
             self.text = self.type
 
         elif self.type == "bookmark":
-            self.text: str = kwargs[self.type].get("url")
             self.caption = RichTextArray(kwargs[self.type].get("caption"))
+            if self.caption:
+                self.text: str = f'[{self.caption}]({kwargs[self.type].get("url")})'
+            else:
+                self.text: str = f'<{kwargs[self.type]["url"]}>' if kwargs[self.type].get("url") else "*Empty bookmark*"
 
         elif self.type == "equation":
             self.text: str = kwargs[self.type].get("expression")

--- a/pytion/models.py
+++ b/pytion/models.py
@@ -613,8 +613,68 @@ class Block(Model):
             else:
                 self.text: str = f'<{kwargs[self.type]["url"]}>' if kwargs[self.type].get("url") else "*Empty embed*"
 
-        elif self.type in ["image", "video", "file", "pdf", "breadcrumb"]:
-            self.text = self.type
+        elif self.type == "image":
+            self.caption = RichTextArray(kwargs[self.type].get("caption"))
+            subtype = kwargs[self.type].get("type")
+            if subtype == "file":
+                self.expiry_time = Model.format_iso_time(kwargs[self.type][subtype].get("expiry_time"))
+            else:
+                self.expiry_time = None
+            if subtype in ("file", "external"):
+                if self.caption:
+                    self.text = f'[{self.caption}]({kwargs[self.type][subtype].get("url")})'
+                else:
+                    self.text = f'<{kwargs[self.type][subtype].get("url")}>'
+            else:
+                self.text = "*Unknown image type*"
+
+        elif self.type == "video":
+            self.caption = RichTextArray(kwargs[self.type].get("caption"))
+            subtype = kwargs[self.type].get("type")
+            if subtype == "file":
+                self.expiry_time = Model.format_iso_time(kwargs[self.type][subtype].get("expiry_time"))
+            else:
+                self.expiry_time = None
+            if subtype in ("file", "external"):
+                if self.caption:
+                    self.text = f'[{self.caption}]({kwargs[self.type][subtype].get("url")})'
+                else:
+                    self.text = f'<{kwargs[self.type][subtype].get("url")}>'
+            else:
+                self.text = "*Unknown video type*"
+
+        elif self.type == "file":
+            self.caption = RichTextArray(kwargs[self.type].get("caption"))
+            subtype = kwargs[self.type].get("type")
+            if subtype == "file":
+                self.expiry_time = Model.format_iso_time(kwargs[self.type][subtype].get("expiry_time"))
+            else:
+                self.expiry_time = None
+            if subtype in ("file", "external"):
+                if self.caption:
+                    self.text = f'[{self.caption}]({kwargs[self.type][subtype].get("url")})'
+                else:
+                    self.text = f'<{kwargs[self.type][subtype].get("url")}>'
+            else:
+                self.text = "*Unknown file type*"
+
+        elif self.type == "pdf":
+            self.caption = RichTextArray(kwargs[self.type].get("caption"))
+            subtype = kwargs[self.type].get("type")
+            if subtype == "file":
+                self.expiry_time = Model.format_iso_time(kwargs[self.type][subtype].get("expiry_time"))
+            else:
+                self.expiry_time = None
+            if subtype in ("file", "external"):
+                if self.caption:
+                    self.text = f'[{self.caption}]({kwargs[self.type][subtype].get("url")})'
+                else:
+                    self.text = f'<{kwargs[self.type][subtype].get("url")}>'
+            else:
+                self.text = "*Unknown pdf type*"
+
+        elif self.type == "breadcrumb":
+            self.text = "*breadcrumb block*"
 
         elif self.type == "bookmark":
             self.caption = RichTextArray(kwargs[self.type].get("caption"))


### PR DESCRIPTION
Add read support of Block types:

- embed;
- image;
- video;
- file;
- pdf;
- link_preview;
- link_to_page;
- template;
- synced_block;
- table;
- table_row.

Updates:

- breadcrumb;
- bookmark;
- table_of_contents.
- Element.get_block_children() returns Database object if `child_database`

Documation updates:

- Block creating examples.

Fixes:

- `Block.created_by` and `Block.last_edited_by` raises NoneType Exception when `Block.create()` is used.