### PR TITLE
fix error with optional typing.

### DIFF
--- a/pytion/api.py
+++ b/pytion/api.py
@@ -427,7 +427,7 @@ class Element(object):
             parent: Optional[LinkTo] = None,
             properties: Optional[Dict[str, PropertyValue]] = None,
             title: Optional[Union[str, RichTextArray]] = None,
-            children: Optional[BlockArray, List[Block]] = None,
+            children: Union[BlockArray, List[Block], None] = None,
     ) -> Optional[Element]:
         """
         :param page_obj:      you can provide `Page` object or -
@@ -539,7 +539,7 @@ class Element(object):
 
     def block_append(
             self, id_: Optional[str] = None, block: Optional[Block] = None,
-            blocks: Optional[BlockArray, List[Block]] = None
+            blocks: Union[BlockArray, List[Block], None] = None
     ) -> Optional[Element]:
         """
         Append block or blocks children

--- a/pytion/models.py
+++ b/pytion/models.py
@@ -317,7 +317,7 @@ class PropertyValue(Property):
                 self.value = RichTextArray.create(data[self.type])
 
         if self.type == "number":
-            self.value: Optional[int, float] = data["number"]
+            self.value: Union[int, float, None] = data["number"]
 
         if self.type == "select":
             if data["select"] and isinstance(data["select"], dict):
@@ -394,7 +394,7 @@ class PropertyValue(Property):
                     self.value = [PropertyValue(element, rollup_type).value for element in data["rollup"]["array"]]
 
             elif rollup_type == "number":
-                self.value: Optional[int, float] = data["rollup"]["number"]
+                self.value: Union[int, float, None] = data["rollup"]["number"]
 
             elif rollup_type == "date":
                 if data["rollup"]["date"]:
@@ -618,7 +618,7 @@ class Page(Model):
     @classmethod
     def create(
             cls, parent: LinkTo, properties: Optional[Dict[str, PropertyValue]] = None,
-            title: Optional[RichTextArray, str] = None, children: Optional[BlockArray] = None, **kwargs
+            title: Union[RichTextArray, str, None] = None, children: Optional[BlockArray] = None, **kwargs
     ):
         if not properties:
             properties = {}
@@ -1025,7 +1025,7 @@ class LinkTo(object):
     """
 
     def __init__(
-            self, block: Optional[Model] = None, from_object: Optional[Block, Page, Database] = None, **kwargs
+            self, block: Optional[Model] = None, from_object: Union[Block, Page, Database, None] = None, **kwargs
     ):
         """
         Creates LinkTo object from API dict


### PR DESCRIPTION
Optional type accepts only one argument. Optional returns changed from Optional[type 1, type2, ...] to Union[type1, type2, ..., None] for better linting. Compatibility with Python < 3.9 maintained. 
No Black formatting.